### PR TITLE
Start xvfb in the docker_start script so xvfb-run is not required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get install -y nodejs
 ENV APP_HOME /ca_intake
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
-
+ENV DISPLAY :1
 ENV BUNDLE_PATH /ruby_gems

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -4,4 +4,4 @@ bundle check || bundle install
 npm install
 bin/gulp
 
-bin/gulp server & bundle exec puma
+Xvfb :1 -ac +extension RANDR -screen 0 2500x2500x16 & bin/gulp server & bundle exec puma


### PR DESCRIPTION
At the moment, to run a feature test which uses the browser, to run it in docker, you need to run:
xvfb-run bundle exec rspec spec/features

With this change, you don't need to run it within "xvfb-run"

[#128664683]