### PR TITLE
Fix chrome launch issues when running bin/karma within docker container

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,13 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Firefox'],
+    browsers: ['Chrome_no_sandbox', 'Firefox'],
+    customLaunchers: {
+      Chrome_no_sandbox: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
     captureTimeout: 60000,
     browserNoActivityTimeout: 30000,
     singleRun: true,


### PR DESCRIPTION
Karma chrome launcher failed to launch karma with the following warning:
[launcher]: Chrome have not captured in 60000 ms, killing.

[#128499871]